### PR TITLE
Source hardening

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,4 +27,4 @@ PKG_CHECK_MODULES([libconfig], [libconfig], [], [AC_MSG_ERROR([libconfig is requ
 AC_CHECK_FUNC([getopt_long], [AC_DEFINE([HAVE_GETOPT_LONG],[1],[getopt_long support])])
 AC_CHECK_FUNC([nftw], [AC_DEFINE([HAVE_NFTW],[1],[nftw support])], [
 			AC_MSG_ERROR([unable to find the nftw() function])])
-AC_OUTPUT(src/Makefile src/freight-builder/Makefile src/freight-agent/Makefile)
+AC_OUTPUT(src/Makefile src/freight-builder/Makefile src/freight-agent/Makefile src/tests/Makefile)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = . freight-builder freight-agent
+SUBDIRS = . freight-builder freight-agent tests

--- a/src/freight-agent/Makefile.am
+++ b/src/freight-agent/Makefile.am
@@ -8,8 +8,8 @@ bin_PROGRAMS = freight-agent freightctl
 
 freight_agent_SOURCES = main.c freight-config.c\
 			postgres-db.c mode.c nodb.c\
-			freight-db.c
+			freight-db.c ../freight-common.c
 
 freightctl_SOURCES = freightctl_main.c \
 		freight-config.c postgres-db.c\
-		nodb.c freight-db.c
+		nodb.c freight-db.c ../freight-common.c

--- a/src/freight-agent/freight-config.c
+++ b/src/freight-agent/freight-config.c
@@ -31,6 +31,9 @@
 
 void release_configuration(struct agent_config *config)
 {
+	if (!config)
+		return;
+	
 	free(config->db.hostaddr);
 	free(config->db.dbname);
 	free(config->db.user);

--- a/src/freight-agent/freight-config.c
+++ b/src/freight-agent/freight-config.c
@@ -26,8 +26,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <libconfig.h>
-#include <freight-log.h>
 #include <freight-config.h>
+#include <freight-common.h>
 
 void release_configuration(struct agent_config *config)
 {
@@ -39,6 +39,23 @@ void release_configuration(struct agent_config *config)
 	free(config->db.user);
 	free(config->db.password);
 	free(config->node.container_root);
+}
+
+static int parse_entry(config_setting_t *config, char **b, const char *name) {
+	config_setting_t *t;
+	char *p;
+
+	t = config_setting_get_member(config, name);
+	if (!t)
+		return -ENOENT;
+
+	p = strdup(config_setting_get_string(t));
+	if (!p)
+		return -ENOMEM;
+
+	*b = p;
+
+	return 0;
 }
 
 static int parse_db_config(config_t *cfg, struct db_config *db)
@@ -59,7 +76,7 @@ static int parse_db_config(config_t *cfg, struct db_config *db)
 		goto out;
 	}
 
-	if (!strcmp(config_setting_get_string(tmp), "postgres"))
+	if (streq(config_setting_get_string(tmp), "postgres"))
 		db->dbtype = DB_TYPE_POSTGRES;
 	else {
 		LOG(ERROR, "Unknown DB type\n");
@@ -71,22 +88,22 @@ static int parse_db_config(config_t *cfg, struct db_config *db)
 	/*
  	 * hostaddr, dbname, user and pass are all optional based on type
  	 */
-	tmp = config_setting_get_member(db_cfg, "hostaddr");
-	if (tmp)
-		db->hostaddr = strdup(config_setting_get_string(tmp));
+	rc = parse_entry(db_cfg, &db->hostaddr, "hostaddr");
+	if (rc < 0)
+		return rc;
 
-	tmp = config_setting_get_member(db_cfg, "dbname");
-	if (tmp)
-		db->dbname = strdup(config_setting_get_string(tmp));
+	rc = parse_entry(db_cfg, &db->dbname, "dbname");
+	if (rc < 0)
+		return rc;
 
-	tmp = config_setting_get_member(db_cfg, "user");
-	if (tmp)
-		db->user = strdup(config_setting_get_string(tmp));
+	rc = parse_entry(db_cfg, &db->user, "user");
+	if (rc < 0)
+		return rc;
 
-	tmp = config_setting_get_member(db_cfg, "password");
-	if (tmp)
-		db->password = strdup(config_setting_get_string(tmp));
-	
+	rc = parse_entry(db_cfg, &db->password, "password");
+	if (rc < 0)
+		return rc;
+
 out:
 	return rc;
 }
@@ -103,14 +120,10 @@ static int parse_node_config(config_t *cfg, struct node_config *node)
 	if (!node_cfg)
 		goto out;
 	
-	tmp = config_setting_get_member(node_cfg, "container_root");
-	if (!tmp) {
-		rc = -EINVAL;
-		LOG(ERROR, "node config must contain a container_root");
-		goto out;
-	}
-
-	node->container_root = strdup(config_setting_get_string(tmp));
+	rc = parse_entry(node_cfg, &node->container_root, "container_root");
+	if (rc == -ENOENT) 
+		LOG(ERROR, "node config must contain a valid container_root");
+	
 out:
 	return rc;
 }

--- a/src/freight-agent/freight-config.h
+++ b/src/freight-agent/freight-config.h
@@ -23,7 +23,6 @@
 #ifndef _FREIGHT_CONFIG_H_
 #define _FREIGHT_CONFIG_H_
 
-
 enum db_type {
 	DB_TYPE_NONE = 0,
 	DB_TYPE_POSTGRES,

--- a/src/freight-agent/freight-db.c
+++ b/src/freight-agent/freight-db.c
@@ -89,7 +89,7 @@ int add_repo(const struct db_api *api,
 		return -EOPNOTSUPP;
 
 	sql = strjoina("INSERT INTO yum_config VALUES ('", name, "', '",
-			url, "', '", acfg->db.user, "')");
+			url, "', '", acfg->db.user, "')", NULL);
 
 	return api->send_raw_sql(sql, acfg);
 }
@@ -104,7 +104,7 @@ extern int del_repo(const struct db_api *api,
 		return -EOPNOTSUPP;
 
 	sql = strjoina("DELETE FROM yum_config WHERE name = '", name, 
-		"' AND tennant='", acfg->db.user, "'");
+		"' AND tennant='", acfg->db.user, "'", NULL);
 
 	return api->send_raw_sql(sql, acfg);
 }
@@ -119,7 +119,7 @@ int add_host(const struct db_api *api,
 	if (!api->send_raw_sql)
 		return -EOPNOTSUPP;
 
-	sql = strjoina("INSERT INTO nodes VALUES ('", hostname, "', 'offline')");
+	sql = strjoina("INSERT INTO nodes VALUES ('", hostname, "', 'offline')", NULL);
 
 	return api->send_raw_sql(sql, acfg);
 }
@@ -133,7 +133,7 @@ int del_host(const struct db_api *api,
 	if (!api->send_raw_sql)
 		return -EOPNOTSUPP;
 
-	sql = strjoina("DELETE FROM nodes WHERE hostname = '", hostname ,"'");
+	sql = strjoina("DELETE FROM nodes WHERE hostname = '", hostname, "'", NULL);
 
 	return api->send_raw_sql(sql, acfg);
 }
@@ -148,7 +148,7 @@ int subscribe_host(const struct db_api *api,
 	if (!api->send_raw_sql)
 		return -EOPNOTSUPP;
 
-	sql = strjoina("INSERT INTO tennant_hosts VALUES('", tenant, "', '", host, "')");
+	sql = strjoina("INSERT INTO tennant_hosts VALUES('", tenant, "', '", host, "')", NULL);
 
 	return api->send_raw_sql(sql, acfg);
 }
@@ -164,7 +164,7 @@ int unsubscribe_host(const struct db_api *api,
 		return -EOPNOTSUPP;
 
 	sql = strjoina("DELETE FROM tennant_hosts WHERE hostname = '", 
-			host,"' AND tennant = '", tenant,"'");
+			host,"' AND tennant = '", tenant, "'", NULL);
 
 	return api->send_raw_sql(sql, acfg);
 }
@@ -182,7 +182,7 @@ int list_subscriptions(const struct db_api *api,
 	if (!api->get_table)
 		return -EOPNOTSUPP;
 
-	filter = strjoina("tennant = '", real_tenant, "'");
+	filter = strjoina("tennant = '", real_tenant, "'", NULL);
 
 	table = api->get_table("tennant_hosts", "*", filter, acfg);
 	if (!table)
@@ -207,7 +207,7 @@ struct tbl* get_tennants_for_host(const struct db_api *api,
 	if (!api->get_table)
 		return NULL;
 
-	filter = strjoina("hostname = '", host, "'");
+	filter = strjoina("hostname = '", host, "'", NULL);
 
 	return api->get_table("tennant_hosts", "*", filter, acfg);
 }
@@ -221,7 +221,7 @@ struct tbl* get_repos_for_tennant(const struct db_api *api,
 	if (!api->get_table)
 		return NULL;
 
-	filter = strjoina("tennant='", tenant, "'");
+	filter = strjoina("tennant='", tenant, "'", NULL);
 
 	return api->get_table("yum_config", "name, url", filter, acfg);
 }

--- a/src/freight-agent/main.c
+++ b/src/freight-agent/main.c
@@ -25,7 +25,7 @@
 #include <getopt.h>
 #include <string.h>
 #include <config.h>
-#include <freight-log.h>
+#include <freight-common.h>
 #include <freight-config.h>
 #include <freight-db.h>
 #include <mode.h>
@@ -136,19 +136,19 @@ int main(int argc, char **argv)
 		goto out_release;
 	}
 
-	if (!strcmp(mode, "node"))
+	if (streq(mode, "node"))
 		config.cmdline.mode = OP_MODE_NODE;
-	else if (!strcmp(mode, "init"))
+	else if (streq(mode, "init"))
 		config.cmdline.mode = OP_MODE_INIT; 
-	else if (!strcmp(mode, "clean"))
+	else if (streq(mode, "clean"))
 		config.cmdline.mode = OP_MODE_CLEAN;
-	else if (!strcmp(mode, "install"))
+	else if (streq(mode, "install"))
 		config.cmdline.mode = OP_MODE_INSTALL;
-	else if (!strcmp(mode, "uninstall"))
+	else if (streq(mode, "uninstall"))
 		config.cmdline.mode = OP_MODE_UNINSTALL;
-	else if (!strcmp(mode, "list"))
+	else if (streq(mode, "list"))
 		config.cmdline.mode = OP_MODE_LIST;
-	else if (!strcmp(mode, "exec"))
+	else if (streq(mode, "exec"))
 		config.cmdline.mode = OP_MODE_EXEC;
 	else {
 		LOG(ERROR, "Invalid mode spcified\n");

--- a/src/freight-agent/mode.c
+++ b/src/freight-agent/mode.c
@@ -99,7 +99,7 @@ void list_containers(char *scope, const char *tenant,
 	else {
 		char *status = streq(scope, "local") ? "installed" : "all";
 		char *cmd = strjoina("yum --installroot=", acfg->node.container_root, 
-				"/", tenant, " ", status, NULL);
+				"/", tenant, " local ", status, NULL);
 
 		run_command(cmd, 1); 
 	}
@@ -180,7 +180,6 @@ static int init_tennant_root(const struct db_api *api,
 	rc = -EINVAL;
 	LOG(INFO, "Building freight-agent environment\n");
 	for (i=0; dirs[i]; i++) {
-
 		rc = build_dir(troot, dirs[i]);
 		if (rc) {
 			LOG(ERROR, "Could not create %s: %s\n",

--- a/src/freight-agent/mode.c
+++ b/src/freight-agent/mode.c
@@ -29,7 +29,6 @@
 #include <libconfig.h>
 #include <mode.h>
 #include <freight-log.h>
-#include <freight-db.h>
 #include <freight-common.h>
 
 
@@ -68,6 +67,8 @@ static int parse_container_options(char *config_path,
 		goto out;
 
 	copts->user = strdup(config_setting_get_string(tmp2));
+	if (!copts->user)
+		rc = -ENOMEM;
 
 out:
 	config_destroy(&config);
@@ -76,108 +77,81 @@ out:
 
 static int build_dir(const char *base, const char *path)
 {
-	char *tmp = alloca(strlen(base) + strlen(path) + 4);
-	strcpy(tmp, base);
-	strcat(tmp, "/");
-	if (path)
-		strcat(tmp, path);
-	return mkdir(tmp, 0700);
+	char *p = strjoina(base, "/", path);
+	if (!p)
+		return -ENOMEM;
+
+	return mkdir(p, 0700);
 }
 
 static char *build_path(const char *base, const char *path, char *name)
 {
-	char *out;
-	size_t tsz;
-
-	tsz = strlen(base) + strlen(path) + 2;
-
-	if (name)
-		tsz += strlen(name);
-
-	out = calloc(1, tsz);
-	if (out) {
-		out = strcpy(out, base);
-		out = strcat(out, path);
-		if (name)
-			strcat(out, name);
-	}
-	return out;
+	return strjoin(base, path, name, NULL);
 }
 
 void clean_container_root(const char *croot)
 {
 	recursive_dir_cleanup(croot);
-	return;
 }
 
-void list_containers(char *scope, const char *tennant,
+void list_containers(char *scope, const char *tenant,
 		     struct agent_config *acfg)
 {
-	char cmd[1024];
-
-	if (!strcmp(scope, "running")) {
+	if (streq(scope, "running"))
 		run_command("machinectl list", 1);
-		return;
+	else {
+		char *status = streq(scope, "local") ? "installed" : "all";
+		char *cmd = strjoina("yum --installroot=", acfg->node.container_root, 
+				"/", tenant, " ", status);
+
+		run_command(cmd, 1); 
 	}
-
-	sprintf(cmd, "yum --installroot=%s/%s list %s",
-		acfg->node.container_root, tennant,
-		!strcmp(scope, "local") ? "installed" : "all");
-
-	run_command(cmd, 1); 
-
-	return;
 }
 
-int install_container(const char *rpm, const char *tennant,
+int install_container(const char *rpm, const char *tenant,
 		      struct agent_config *acfg)
 {
 	struct stat buf;
 	int rc = -ENOENT;
-	char yumcmd[1024];
-	char *troot = alloca(strlen(acfg->node.container_root) +
-			     strlen(tennant) + 10);
+	char *yumcmd;
+	char *troot;
 
-	sprintf(troot, "%s/%s", acfg->node.container_root, tennant);
+	troot = strjoina(acfg->node.container_root, "/", tenant);
 
 	if (stat(troot, &buf) == -ENOENT) {
 		LOG(ERROR, "Container root isn't initalized\n");
 		goto out;
 	}
 
-	sprintf(yumcmd, "yum --installroot=%s -y --nogpgcheck install %s",
-		troot, rpm);
-
+	yumcmd = strjoina("yum --installroot=", troot, " -y --nogpgcheck install ", rpm);
 	rc = run_command(yumcmd, acfg->cmdline.verbose);
 
 out:
 	return rc;
 }
 
-int uninstall_container(const char *rpm, const char *tennant,
+int uninstall_container(const char *rpm, const char *tenant,
 			struct agent_config *acfg)
 {
-	char yumcmd[1024];
+	char *yumcmd, *croot;
 	struct stat buf;
 	int rc = -ENOENT;
 
-	sprintf(yumcmd, "%s/%s/containers/%s", acfg->node.container_root,
-		tennant, rpm);
+	croot = strjoina(acfg->node.container_root, "/", tenant, "/containers/", rpm);
 
-	if (stat(yumcmd, &buf) == -ENOENT)
+	if (stat(croot, &buf) == -ENOENT)
 		goto out;
 
-	sprintf(yumcmd, "yum --installroot=%s/%s -y erase %s",
-		acfg->node.container_root, tennant, rpm);
-	rc = run_command(yumcmd, acfg->cmdline.verbose);
+	yumcmd = strjoina("yum --installroot=", acfg->node.container_root, "/", tenant, " -y erase ", rpm);
 
+	rc = run_command(yumcmd, acfg->cmdline.verbose);
 out:
 	return rc;
 }
 
 static int init_tennant_root(const struct db_api *api,
 			       const char *croot,
-			       const char *tennant,
+			       const char *tenant,
 			       const struct agent_config *acfg)
 {
 	char *dirs[]= {
@@ -193,14 +167,14 @@ static int init_tennant_root(const struct db_api *api,
 		"etc/yum.repos.d",
 		NULL,
 	};
-	char *troot = alloca(strlen(croot) + strlen(tennant) + 10); 
-	char *tmp;
-	char repo[1024];
+	char *troot;
+	__free char *tmp = NULL;
+	char *repo;
 	int i, rc;
 	FILE *fptr;
 	struct tbl *yum_config = NULL;
 
-	sprintf(troot, "%s/%s/", croot, tennant);
+	troot = strjoina(croot, "/", tenant, "/");
 
 	/*
  	 * Sanity check the container root, it can't be the 
@@ -224,6 +198,9 @@ static int init_tennant_root(const struct db_api *api,
  	 * it
  	 */
 	tmp = build_path(troot, "/etc/yum.conf", NULL);
+	if (!tmp)
+		return -ENOMEM;
+
 	fptr = fopen(tmp, "w");
 	if (!fptr) {
 		rc = errno;
@@ -231,7 +208,6 @@ static int init_tennant_root(const struct db_api *api,
 			strerror(errno));
 		goto out_cleanup;
 	}
-	free(tmp);
 
 	fprintf(fptr, "[main]\n");
 	fprintf(fptr, "cachedir=/var/cache/yum/$basearch/$releasever\n");
@@ -242,15 +218,14 @@ static int init_tennant_root(const struct db_api *api,
 	/*
  	 * Now we need to check the database for our repository configuration
  	 */
-	yum_config = get_repos_for_tennant(api, tennant, acfg);
+	yum_config = get_repos_for_tennant(api, tenant, acfg);
  
 	if (!yum_config)
 		LOG(WARNING, "No yum config in database, we won't be able "
 			     "to fetch containers!\n");
 	else {
 		for (i=0; i < yum_config->rows; i++) {
-			snprintf(repo, 1024, "%s/etc/yum.repos.d/%s.repo", troot,
-				 yum_config->value[i][0]);
+			repo = strjoina(troot, "/etc/yum.repos.d/", yum_config->value[i][0], ".repo");
 			fptr = fopen(repo, "w");
 			if (!fptr) {
 				LOG(ERROR, "Unable to write /etc/yum.repos.d/%s.repo\n",
@@ -268,11 +243,13 @@ static int init_tennant_root(const struct db_api *api,
 
 		free_tbl(yum_config);
 	}
-out:
-	return rc;
+
+	goto out;
+
 out_cleanup:
 	clean_container_root(troot);
-	goto out;
+out:
+	return rc;
 }
 
 int init_container_root(const struct db_api *api,
@@ -288,7 +265,7 @@ int init_container_root(const struct db_api *api,
 	 * system root
 	 */
 	rc = -EINVAL;
-	if (!strcmp(croot, "/")) {
+	if (streq(croot, "/")) {
 		LOG(ERROR, "container root cannot be system root!\n");
 		goto out;
 	}
@@ -362,16 +339,15 @@ static void daemonize(const struct agent_config *acfg)
 	}
 }
 
-int exec_container(const char *rpm, const char *name, const char *tennant,
+int exec_container(const char *rpm, const char *name, const char *tenant,
                    const struct agent_config *acfg)
 {
 	pid_t pid;
 	int eoc;
 	struct container_options copts;
-	char config_path[1024];
+	char *config_path;
 
-	sprintf(config_path, "%s/%s/containers/%s/container_config",
-		acfg->node.container_root, tennant, rpm);
+	config_path = strjoina(acfg->node.container_root, "/", tenant, "/containers/", rpm, "/container_config");
 
 	/*
  	 * Lets parse the container configuration
@@ -421,8 +397,8 @@ int exec_container(const char *rpm, const char *name, const char *tennant,
 	if (!execarray)
 		exit(1);
 
-	sprintf(config_path, "%s/%s/containers/%s/containerfs",
-		acfg->node.container_root, tennant, rpm);
+	config_path = strjoina(acfg->node.container_root, "/", tenant, "/containers/", rpm, "/containerfs");
+
 	eoc = 0;
 	execarray[eoc++] = "systemd-nspawn"; /* argv[0] */
 	execarray[eoc++] = "-D"; /* -D */

--- a/src/freight-builder/Makefile.am
+++ b/src/freight-builder/Makefile.am
@@ -5,5 +5,5 @@ AM_LDFLAGS = ${libconfig_LIBS}
 
 bin_PROGRAMS = freight-builder
 
-freight_builder_SOURCES = main.c manifest.c manifest.h package.h package.c yum.c
+freight_builder_SOURCES = main.c manifest.c manifest.h package.h package.c yum.c ../freight-common.c
 

--- a/src/freight-builder/manifest.c
+++ b/src/freight-builder/manifest.c
@@ -130,10 +130,9 @@ static int parse_repositories(struct config_t *config, struct manifest *manifest
 
 	config_setting_t *repos = config_lookup(config, "repositories");
 	config_setting_t *repo, *tmp;
-	__free_repos struct repository *repop = NULL;
+	/*__free_repos */struct repository *repop = NULL;
 	struct repository *last = manifest->repos;
 	int i = 0;
-	size_t alloc_size;
 	const char *name, *url;
 
 	if (!repos)
@@ -190,14 +189,15 @@ static int parse_rpms(struct config_t *config, struct manifest *manifest)
 {
 	config_setting_t *rpms = config_lookup(config, "manifest");
 	config_setting_t *rpm_config;
-	__free_rpms struct rpm *rpmp = NULL;
+	/*__free_rpms*/ struct rpm *rpmp = NULL;
+	struct rpm *last = manifest->rpms;
 	int i = 0;
-	size_t alloc_size;
 	const char *name;
 
 	if (!rpms)
 		return 0;
 
+	//printf("*-* *-*\n");
 	/*
  	 * Load up all the individual repository urls
  	 */
@@ -215,12 +215,19 @@ static int parse_rpms(struct config_t *config, struct manifest *manifest)
 		if (!rpmp->name)
 			return -ENOMEM;
 
-		rpmp->next = manifest->rpms;
-		manifest->rpms = rpmp;	
+		//printf(" ** %s [%p %p %p]\n", rpmp->name, rpmp, last, rpmp->name);
+
+		rpmp->next = NULL;
+		if (last)
+			last->next = rpmp;
+		else
+			manifest->rpms = rpmp;
+		last = rpmp;
 		
 		i++;
 	}
 
+	//printf("*=* *=*\n");
 	rpmp = NULL;
 
 	return 0;

--- a/src/freight-builder/manifest.c
+++ b/src/freight-builder/manifest.c
@@ -28,27 +28,62 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <libconfig.h>
-#include <freight-log.h>
+#include <freight-common.h>
 #include <manifest.h>
+
+void release_repos(struct repository *repos) {
+	struct repository *r = repos, *k = NULL;
+	while (r) {
+		k = r;
+		free(r->name);
+		free(k->url);
+		r = r->next;
+		free(k);
+	}
+}
+
+void release_rpms(struct rpm *rpms) {
+	struct rpm *r = rpms, *k = NULL;
+	while (r) {
+		k = r;
+		free(r->name);
+		r = r->next;
+		free(k);
+	}
+}
+
+CLEANUP_FUNC(struct repository*, release_repos);
+CLEANUP_FUNC(struct rpm*, release_rpms);
+#define __free_repos __cleanup(release_reposp)
+#define __free_rpms __cleanup(release_rpmsp)
 
 void release_manifest(struct manifest *manifest)
 {
+	if (!manifest)
+		return;
+
 	struct repository *repos = manifest->repos;
 	struct rpm *rpms = manifest->rpms;
 	void *killer;
 
+	release_rpms(rpms);
+/*
 	while (rpms) {
 		killer = rpms;
 		rpms = rpms->next;
 		free(killer);
 	}
-
+*/
+	release_repos(repos);
+/*
 	while (repos) {
 		killer = repos;
+		free(repos->name);
+		free(repos->url);
 		repos = repos->next;
 		free(killer);
 	}
-
+*/
 	if (manifest->options)
 		free(manifest->options);
 
@@ -65,6 +100,9 @@ void release_manifest(struct manifest *manifest)
 
 static int parse_yum_opts(struct config_t *config, struct manifest *manifest)
 {
+	if (!config || !manifest)
+		return -EINVAL;
+
 	config_setting_t *yum_opts = config_lookup(config, "yum_opts");
 	config_setting_t *releasever;
 
@@ -75,18 +113,25 @@ static int parse_yum_opts(struct config_t *config, struct manifest *manifest)
 		return 0;
 
 	releasever = config_setting_get_member(yum_opts, "releasever");
-	if (releasever)
+	if (releasever) {
 		manifest->yum.releasever = strdup(
 				config_setting_get_string(releasever));
+		if (!manifest->yum.releasever) 
+			return -ENOMEM;		
+	}
 
 	return 0;
 }
 
 static int parse_repositories(struct config_t *config, struct manifest *manifest)
 {
+	if (!config || !manifest)
+		return -EINVAL;
+
 	config_setting_t *repos = config_lookup(config, "repositories");
 	config_setting_t *repo, *tmp;
-	struct repository *repop;
+	__free_repos struct repository *repop = NULL;
+	struct repository *last = manifest->repos;
 	int i = 0;
 	size_t alloc_size;
 	const char *name, *url;
@@ -112,32 +157,31 @@ static int parse_repositories(struct config_t *config, struct manifest *manifest
 		if (!url)
 			return -EINVAL;
 
-		/*
- 		 * Add two for the null terminators
- 		 */
-		alloc_size = strlen(name) + strlen(url) + 2;
-
-		repop = calloc(1, sizeof(struct repository) + alloc_size);
+		repop = calloc(1, sizeof(struct repository));
 		if (!repop)
 			return -ENOMEM;
 
-		/*
- 		 * Allocate memory for strings at the end of the repository
- 		 * structure so that we can free it as a unit
- 		 */
-		repop->name = (char *)((void *)repop + sizeof(struct repository));
-		/*
- 		 * Add one for the null terminator
- 		 */
-		repop->url = (char *)((void *)repop + sizeof(struct repository) + strlen(name))+1;
-		strcpy(repop->name, name);
-		strcpy(repop->url, url); 
+		repop->name = strdup(name);
+		if (!repop->name)
+			return -ENOMEM;
 
-		repop->next = manifest->repos;
-		manifest->repos = repop;	
+		repop->url = strdup(url);
+		if (!repop->url) {
+			free(repop->name);
+			return -ENOMEM;
+		}
+
+		repop->next = NULL;
+		if (last)
+			last->next = repop;
+		else
+			manifest->repos = repop;
+		last = repop;
 		
 		i++;
 	}
+	
+	repop = NULL;
 
 	return 0;
 }
@@ -146,7 +190,7 @@ static int parse_rpms(struct config_t *config, struct manifest *manifest)
 {
 	config_setting_t *rpms = config_lookup(config, "manifest");
 	config_setting_t *rpm_config;
-	struct rpm *rpmp;
+	__free_rpms struct rpm *rpmp = NULL;
 	int i = 0;
 	size_t alloc_size;
 	const char *name;
@@ -163,24 +207,21 @@ static int parse_rpms(struct config_t *config, struct manifest *manifest)
 		if (!name)
 			return -EINVAL;
 
-		alloc_size = strlen(name);
-
-		rpmp = calloc(1, sizeof(struct rpm) + alloc_size);
+		rpmp = calloc(1, sizeof(struct rpm));
 		if (!rpmp)
 			return -ENOMEM;
 
-		/*
- 		 * Allocate memory for strings at the end of the repository
- 		 * structure so that we can free it as a unit
- 		 */
-		rpmp->name = (char *)(rpmp + 1);
-		strcpy(rpmp->name, name);
+		rpmp->name = strdup(name);
+		if (!rpmp->name)
+			return -ENOMEM;
 
 		rpmp->next = manifest->rpms;
 		manifest->rpms = rpmp;	
 		
 		i++;
 	}
+
+	rpmp = NULL;
 
 	return 0;
 }
@@ -196,12 +237,15 @@ static int parse_packaging(struct config_t *config, struct manifest *manifest)
 		goto out;
 	}
 
+	rc = -ENOMEM;
 	tmp = config_setting_get_member(pkg, "name");
 	if (!tmp) {
 		LOG(ERROR, "You must specify a package name\n");
 		goto out;
 	}
 	manifest->package.name = strdup(config_setting_get_string(tmp));
+	if (!manifest->package.name)
+		goto out;
 
 	tmp = config_setting_get_member(pkg, "version");
 	if (!tmp) {
@@ -209,6 +253,8 @@ static int parse_packaging(struct config_t *config, struct manifest *manifest)
 		goto out_name;
 	}
 	manifest->package.version = strdup(config_setting_get_string(tmp));
+	if (!manifest->package.version)
+		goto out_name;
 
 	tmp = config_setting_get_member(pkg, "release");
 	if (!tmp) {
@@ -216,6 +262,8 @@ static int parse_packaging(struct config_t *config, struct manifest *manifest)
 		goto out_version;
 	}
 	manifest->package.release = strdup(config_setting_get_string(tmp));
+	if (!manifest->package.release)
+		goto out_version;
 
 	tmp = config_setting_get_member(pkg, "summary");
 	if (!tmp) {
@@ -223,6 +271,8 @@ static int parse_packaging(struct config_t *config, struct manifest *manifest)
 		goto out_release;
 	}
 	manifest->package.summary = strdup(config_setting_get_string(tmp));
+	if (!manifest->package.summary)
+		goto out_release;
 
 	tmp = config_setting_get_member(pkg, "license");
 	if (!tmp) {
@@ -230,6 +280,8 @@ static int parse_packaging(struct config_t *config, struct manifest *manifest)
 		goto out_summary;
 	}
 	manifest->package.license = strdup(config_setting_get_string(tmp));
+	if (!manifest->package.license)
+		goto out_summary;
 
 	tmp = config_setting_get_member(pkg, "author");
 	if (!tmp) {
@@ -237,16 +289,22 @@ static int parse_packaging(struct config_t *config, struct manifest *manifest)
 		goto out_license;
 	}
 	manifest->package.author = strdup(config_setting_get_string(tmp));
-
+	if (!manifest->package.author)
+		goto out_license;
 	
 	tmp = config_setting_get_member(pkg, "post_script");
-	if (tmp)
+	if (tmp) {
 		manifest->package.post_script = 
 			strdup(config_setting_get_string(tmp));
+		if (!manifest->package.post_script)
+			goto out_author;
+	}
 
 	rc = 0;
 	goto out;
 
+out_author:
+	free(manifest->package.author);
 out_license:
 	free(manifest->package.license);
 out_summary:
@@ -271,9 +329,12 @@ static int parse_container_opts(config_t *config, struct manifest *manifest)
 
 	tmp = config_setting_get_member(copts, "user");
 
-	if (tmp)
+	if (tmp) {
 		manifest->copts.user = strdup(
 			config_setting_get_string(tmp));
+		if (!manifest->copts.user)
+			return -ENOMEM;
+	}
 
 	return 0;	
 }

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -54,7 +54,7 @@ static char *build_rpm_list(const struct manifest *manifest)
 	unsigned i;
 	size_t a = 0;
 	struct rpm *rpm;
-	__free_strv const char **strings = NULL;
+	__free const char **strings = NULL;
 
 	if (!manifest)
 		return NULL;

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -34,9 +34,8 @@
 #include <freight-log.h>
 #include <freight-common.h>
 
-static char worktemplate[256];
+static char *worktemplate;
 static char *workdir;
-static char tmpdir[1024];
 
 static void yum_cleanup()
 {
@@ -46,38 +45,31 @@ static void yum_cleanup()
 
 static int build_path(const char *path)
 {
-	sprintf(tmpdir, "%s/%s",
-		workdir, path);
+	char *tmpdir = strjoina(workdir, "/", path, NULL);
 	return mkdir(tmpdir, 0700);
 }
 
 static char *build_rpm_list(const struct manifest *manifest)
 {
-	size_t alloc_size = 0;
-	int count;
-	char *result;
-	struct rpm *rpm = manifest->rpms;
+	unsigned i;
+	size_t a = 0;
+	struct rpm *rpm;
+	__free_strv const char **strings = NULL;
 
-	while (rpm) {
-		/* Add an extra character for the space */
-		alloc_size += strlen(rpm->name) + 2;
-		rpm = rpm->next;
-	}
-
-
-	result =  calloc(1, alloc_size);
-	if (!result)
+	if (!manifest)
 		return NULL;
 
 	rpm = manifest->rpms;
-	count = 0;
-	while (rpm) {
-		/* Add 2 to include the trailing space */
-		count += snprintf(&result[count], strlen(rpm->name)+2 , "%s ", rpm->name);
+	for (i = 0; rpm; i++) {
+		if(!__realloc(strings, a, i+1))
+			return NULL;
+
+		strings[i] = rpm->name;
+		strings[i+1] = NULL;
 		rpm = rpm->next;
 	}
 
-	return result;
+	return strvjoin(strings, " ");
 }
 
 /*
@@ -85,14 +77,12 @@ static char *build_rpm_list(const struct manifest *manifest)
  */
 static int yum_build_rpm(const struct manifest *manifest)
 {
-	char cmd[1024];
+	char *cmd;
 	char *output_path;
 	struct utsname utsdata;
 	int rc;
 	char *quiet = manifest->opts.verbose ? "" : "--quiet";
-
-	output_path = manifest->opts.output_path ? manifest->opts.output_path :
-			workdir;
+	output_path = manifest->opts.output_path ?: workdir;
 
 	uname(&utsdata);
 
@@ -103,23 +93,13 @@ static int yum_build_rpm(const struct manifest *manifest)
  	 */
 	setenv("QA_RPATHS", "0x0001", 1);
 
-	/*
- 	 * This will convert the previously built srpm into a binary rpm that
- 	 * can serve as a containerized directory for systemd-nspawn
- 	 */
-	snprintf(cmd, 1024, "rpmbuild %s "
-		 "-D\"_build_name_fmt "
-		 "%s-%s-%s.%%%%{ARCH}.rpm\" "
-		 "-D\"__arch_install_post "
-		 "/usr/lib/rpm/check-rpaths /usr/lib/rpm/check-buildroot\" "
-		 "-D\"_rpmdir %s\" "
-		 "--rebuild %s/%s-%s-%s.src.rpm\n",
-		 quiet, 
-		 manifest->package.name, manifest->package.version,
-		 manifest->package.release,
-		 output_path, output_path,
-		 manifest->package.name, manifest->package.version,
-		 manifest->package.release);
+	cmd = strjoina("rpmbuild ", quiet, " -D\"_build_name_fmt ",
+			manifest->package.name, "-", manifest->package.version, "-",
+			manifest->package.release, ".%%{ARCH}.rpm\" -D\"__arch_install_post "
+			"/usr/lib/rpm/check-rpaths /usr/lib/rpm/check-buildroot\" -D\"_rpmdir ",
+			output_path, "\" --rebuild ", output_path, "/",
+			manifest->package.name, "-", manifest->package.version, "-",
+			manifest->package.release, ".src.rpm\n", NULL);
 	LOG(INFO, "Building container binary rpm\n");
 	rc = run_command(cmd, manifest->opts.verbose);
 	if (!rc)
@@ -133,8 +113,11 @@ static int yum_build_rpm(const struct manifest *manifest)
 
 static int yum_init(const struct manifest *manifest)
 {
-	getcwd(worktemplate, 256);
-	strcat(worktemplate, "/freight-builder.XXXXXX"); 
+	char path[1024];
+	getcwd(path, 1024);
+	worktemplate = strjoin(path, "/freight-builder.XXXXXX", NULL);
+	if (!worktemplate)
+		return -ENOMEM;
 
 	workdir = mkdtemp(worktemplate);
 	if (workdir == NULL) {
@@ -150,7 +133,8 @@ static int stage_workdir(const struct manifest *manifest)
 	struct repository *repo;
 	FILE *repof;
 	char *rpmlist;
-	char pbuf[1024];
+	char *tmpdir;
+	char *pbuf;
 	config_t config;
 	config_setting_t *tmp;
 	char *dirlist[] = {
@@ -174,7 +158,7 @@ static int stage_workdir(const struct manifest *manifest)
 		goto cleanup_tmpdir;
 	}
 
-	sprintf(pbuf, "containers/%s", manifest->package.name); 
+	pbuf = strjoina("containers/", manifest->package.name, NULL); 
 	if (build_path(pbuf)) {
 		LOG(ERROR, "Cannot create container name directory: %s\n",
 			strerror(errno));
@@ -203,8 +187,7 @@ static int stage_workdir(const struct manifest *manifest)
 			goto cleanup_tmpdir;
 		}
 	}
-	sprintf(pbuf, "%s/containers/%s/container_config",
-		workdir, manifest->package.name);
+	pbuf = strjoina(workdir, "/containers/", manifest->package.name, "/container_config", NULL);
 	if (config_write_file(&config, pbuf) == CONFIG_FALSE) {
 		LOG(ERROR, "Failed to write %s: %s\n",
 			pbuf, config_error_text(&config));
@@ -213,14 +196,18 @@ static int stage_workdir(const struct manifest *manifest)
 	config_destroy(&config);
 
 	while(dirlist[i] != NULL) {
-		sprintf(pbuf, "containers/%s/%s",
-			manifest->package.name, dirlist[i]);
+		pbuf = strjoin("containers/", manifest->package.name, "/", dirlist[i], NULL);
+		if (!pbuf)
+			goto cleanup_nomem;
+
 		if (build_path(pbuf)) {
 			LOG(ERROR, "Cannot create %s directory: %s\n",
 				dirlist[i], strerror(errno));
+			free(pbuf);
 			goto cleanup_tmpdir;
 		}
 		i++;
+		free(pbuf);
 	}
 
 	/*
@@ -229,12 +216,16 @@ static int stage_workdir(const struct manifest *manifest)
  	 */
 	repo = manifest->repos;
 	while (repo) {
-		sprintf(tmpdir, "%s/containers/%s/containerfs/etc/yum.repos.d/%s-fb.repo",
-			workdir, manifest->package.name, repo->name);
+		tmpdir = strjoin(workdir, "/containers/", manifest->package.name, "/containerfs/etc/yum.repos.d/",
+				 repo->name, "-fb.repo", NULL);
+		if (!tmpdir)
+			goto cleanup_nomem;
+
 		repof = fopen(tmpdir, "w");
 		if (!repof) {
 			LOG(ERROR, "Error opening %s: %s\n",
 				tmpdir, strerror(errno));
+			free(tmpdir);
 			goto cleanup_tmpdir;
 		}
 
@@ -244,14 +235,15 @@ static int stage_workdir(const struct manifest *manifest)
 		fprintf(repof, "gpgcheck=0\n"); /* for now */
 		fprintf(repof, "enabled=1\n");
 		fclose(repof);
+		free(tmpdir);
 		repo = repo->next;
 	}
 
 	/*
  	 * create a base yum configuration
  	 */
-	sprintf(tmpdir, "%s/containers/%s/containerfs/etc/yum.conf",
-		workdir,manifest->package.name);
+	tmpdir = strjoina(workdir, "/containers/", manifest->package.name,
+			  "/containerfs/etc/yum.conf", NULL);
 	repof = fopen(tmpdir, "w");
 	if (!repof) {
 		LOG(ERROR, "Unable to create a repo configuration: %s\n",
@@ -272,9 +264,7 @@ static int stage_workdir(const struct manifest *manifest)
 	if (!rpmlist)
 		goto cleanup_tmpdir;
 
-	sprintf(tmpdir, "%s/%s.spec", workdir,
-		manifest->package.name);
-
+	tmpdir = strjoina(workdir, "/", manifest->package.name, ".spec", NULL);
 	repof = fopen(tmpdir, "w");
 	if (!repof) {
 		LOG(ERROR, "Unable to create a spec file: %s\n",
@@ -408,6 +398,10 @@ static int stage_workdir(const struct manifest *manifest)
 	fclose(repof);
 
 	return 0;
+cleanup_nomem:
+	yum_cleanup();
+	return -ENOMEM;
+
 cleanup_tmpdir:
 	yum_cleanup();
 	return -EINVAL;
@@ -420,7 +414,7 @@ cleanup_tmpdir:
 static int yum_build_srpm(const struct manifest *manifest)
 {
 	int rc = -EINVAL;
-	char cmd[1024];
+	char *cmd;
 
 	LOG(INFO, "SRPM manifest name is %s\n", manifest->package.name);
 	rc = stage_workdir(manifest);
@@ -432,8 +426,8 @@ static int yum_build_srpm(const struct manifest *manifest)
  	 * Included in the srpm as Source0 of the spec file (written in
  	 * yum_init)
  	 */
-	snprintf(cmd, 1024, "tar -C %s -jcf %s/%s-freight.tbz2 ./containers/\n",
-		workdir, workdir, manifest->package.name);
+	cmd = strjoina("tar -C ", workdir, " -jcf ", workdir, "/", 
+			manifest->package.name, "-freight.tbz2 ./containers/\n", NULL);
 	
 	LOG(INFO, "Creating yum configuration tarball for container\n");
 	rc = run_command(cmd, manifest->opts.verbose);
@@ -441,8 +435,8 @@ static int yum_build_srpm(const struct manifest *manifest)
 		goto out;
 
 	if (manifest->package.post_script) {
-		sprintf(cmd, "cp %s %s/post_script",
-			manifest->package.post_script, workdir);
+		cmd = strjoina("cp ", manifest->package.post_script, " ", 
+				workdir, "/post_script");
 		if (run_command(cmd, manifest->opts.verbose))
 			goto out;
 	}
@@ -453,11 +447,9 @@ static int yum_build_srpm(const struct manifest *manifest)
  	 * optionally direct the srpm dir to the output directory if it was
  	 * specified
  	 */
-	snprintf(cmd, 512, "rpmbuild -D \"_sourcedir %s\" -D \"_srcrpmdir %s\" "
-		"-bs %s/%s.spec\n",
-		workdir,
-		manifest->opts.output_path ? manifest->opts.output_path : workdir,
-		workdir, manifest->package.name);
+	cmd = strjoina("rpmbuild -D \"_sourcedir ", workdir, "\" -D \"_srcrpmdir ",
+			manifest->opts.output_path ? manifest->opts.output_path : workdir, "\" "
+			"-bs ", workdir, "/", manifest->package.name, ".spec\n", NULL);
 	LOG(INFO, "Building container source rpm\n");
 	rc = run_command(cmd, manifest->opts.verbose);
 	if (rc)
@@ -473,9 +465,8 @@ out:
 int yum_inspect(const struct manifest *mfst, const char *rpm)
 {
 	int rc = -EINVAL;
-	char rpmcmd[1024];
+	char *rpmcmd;
 	char *container_name = basename(rpm);
-	char *tmp = strstr(container_name, "");
 
 	if (!container_name) {
 		LOG(ERROR, "Unable to grab file name from path\n");
@@ -486,20 +477,19 @@ int yum_inspect(const struct manifest *mfst, const char *rpm)
 		LOG(ERROR, "unable to create introspect directory\n");
 		goto out;
 	}
-	sprintf(rpmcmd, "yum --installroot=%s/introspect -y --nogpgcheck "
-		"--releasever=%s install %s\n",
-		workdir, mfst->yum.releasever, rpm);
 
+	rpmcmd = strjoina("yum --installroot=", workdir, "/instrospect -y --nogpgcheck ",
+			  "--releasever=", mfst->yum.releasever, " install", rpm, "\n", NULL);
 	LOG(INFO, "Unpacking container\n");
 	rc = run_command(rpmcmd, mfst->opts.verbose);
 	if (rc) {
 		LOG(ERROR, "Unable to install container rpm\n");
 		goto out;
 	}
-	*tmp = '\0'; /* Null Terminate the container name */
+
 	LOG(INFO, "Container name is %s\n", container_name);
-	sprintf(rpmcmd, "yum --installroot %s/introspect/containers/%s/containerfs/ --nogpgcheck check-update",
-		 workdir, container_name);
+	rpmcmd = strjoina("yum --installroot ", workdir, "/introspect/containers/", container_name, 
+			  "/containerfs/ --nogpgcheck check-update", NULL);
 	LOG(INFO, "Looking for packages Requiring update:\n");
 	rc = run_command(rpmcmd, 1);
 

--- a/src/freight-common.c
+++ b/src/freight-common.c
@@ -1,0 +1,159 @@
+/*********************************************************
+ *Copyright (C) 2004 Neil Horman
+ *This program is free software; you can redistribute it and\or modify
+ *it under the terms of the GNU General Public License as published 
+ *by the Free Software Foundation; either version 2 of the License,
+ *or  any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *GNU General Public License for more details.
+ *
+ *File: freight-common.c
+ *
+ *Author: Pavel Odvody
+ *
+ *Date: 6/1/2015
+ *
+ *Description: common utility routines for freight tools 
+ *********************************************************/
+
+#include <freight-common.h>
+
+char *strvjoin(const char **strv, const char *separator) {
+	size_t s = 0, d = 0;
+	unsigned i, k;
+	char *p, *q;
+
+	for (k = 0; strv[k]; ++k) {
+		s += strlen(strv[k]);
+		// catch overflow
+		if (d >= s) 
+			return NULL;
+		d = s;
+	}
+
+	s += (strlen(separator) * (k - 1)) + 1;
+	p = q = malloc(s);
+	if (!p)
+		return NULL;
+
+	for (i = 0; strv[i]; ++i) {
+		q = stpcpy(q, strv[i]);
+		if (i != (k-1))
+			q = stpcpy(q, separator);	
+	}
+	*++q = 0;
+
+	return p;
+}
+
+char *strjoin(const char *a, ...) {
+        va_list l;
+        size_t s = 0, d = 0;
+        const char *p = NULL;
+	char *r = NULL, *x = NULL;
+
+        if (!a)
+                return NULL;
+
+        va_start(l, a);
+        s += strlen(a);
+	d = s;
+
+        for(;;) {
+                bool overflow;
+                p = va_arg(l, const char *);
+                if (!p)
+                        break;
+
+                s += strlen(p);
+                if (d >= s) {
+                        va_end(l);
+                        return NULL;
+                }
+
+                d = s;
+        }
+
+        va_end(l);
+        x = r = malloc(s + 1);
+        if (!r)
+                return NULL;
+
+        r = stpcpy(r, a);
+        va_start(l, a);
+        for (;;) {
+                p = va_arg(l, const char *);
+                if (!p)
+                        break;
+                r = stpcpy(r, p);
+        }
+        va_end(l);
+        *r = 0;
+
+        return x;
+}
+
+inline size_t s_max(size_t a, size_t b) {
+	return a > b ? a : b;
+}
+
+bool streq(const char *a, const char *b) {
+	return strcmp(a, b) == 0;
+}
+
+void *my_realloc(void **b, size_t *size, size_t desired, size_t unit) {
+	size_t newsize;
+	void *q;
+
+	assert(b);
+	assert(size);
+
+	if (*size > desired)
+		return b;
+
+	newsize = s_max(desired * 2, 64/unit);
+	if ((newsize * unit) < (desired * unit))
+		return NULL;
+
+	q = realloc(*b, newsize * unit);
+	if (!q)
+		return NULL;
+
+	*b = q;
+	*size = newsize;
+	return q;
+}
+
+char *strsepjoin(const char* s, ...) {
+	va_list l;
+	__free const char **p = NULL;
+	const char *b = NULL;
+	size_t x = 0, v = 0;
+
+	if (!s)
+		return NULL;
+
+	va_start(l, s);
+
+	for (;;) {
+		b = va_arg(l, const char *);
+		if (!b)
+			break;
+
+		if (!__realloc(p, x, v + 2)) {
+			va_end(l);
+			return NULL;
+		}
+
+		p[v] = b;
+		p[v+1] = NULL;
+		v++;
+	}
+
+	va_end(l);
+	
+	return strvjoin(p, s);
+}

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -1,0 +1,8 @@
+AM_CFLAGS = -Wall -O2 -D_GNU_SOURCE \
+${libconfig_CFLAGS} -I$(top_srcdir)/src/include/
+
+AM_LDFLAGS = ${libconfig_LIBS}
+
+bin_PROGRAMS = test-int
+
+test_int_SOURCES = test-int.c ../freight-common.c

--- a/src/tests/test-int.c
+++ b/src/tests/test-int.c
@@ -1,0 +1,199 @@
+/*********************************************************
+ *Copyright (C) 2015 Pavel Odvody
+ *This program is free software; you can redistribute it and\or modify
+ *it under the terms of the GNU General Public License as published 
+ *by the Free Software Foundation; either version 2 of the License,
+ *or  any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *GNU General Public License for more details.
+ *
+ *File: test-int.c
+ *
+ *Author: Pavel Odvody
+ *
+ *Date: 26.5.2015
+ *
+ *Description
+ *********************************************************/
+
+#include <freight-common.h>
+
+const char *s[] = {
+	"abcd",
+	"test",
+	"blah blah",
+	"string",
+	"aaaaaa",
+	"weweweweew",
+	NULL
+};
+
+void test(int r, const char* header) {
+	if (r == 0) {
+		printf(" \033[1;32mPASS:\033[0m   %s\n", header);
+	} else {
+		printf(" \033[1;31mFAILED:\033[0m %s: %s\n", header, strerror(-r));
+	}
+}
+
+
+void test_ab(const char *a, const char* b) {
+	if (!streq(a, b))
+		printf(" \033[1;31mFAILED:\033[0m streq \n\t '%s' != '%s'\n", a, b);
+	else
+		printf(" \033[1;32mPASS:\033[0m   streq \n\t '%s' == '%s'\n", a, b);
+}
+
+int test_strsepjoin() {
+	char *a = NULL, *b = NULL;
+
+	a = "abcd-->blah blah-->aaaaaa";
+	b = strsepjoin("-->", s[0], s[2], s[4], NULL);
+	test_ab(a, b);
+
+	return 0;
+}
+
+int test_strjoin() {
+	char *a = NULL, *b = NULL;
+
+	a = "abcd + blah blah";
+	b = strjoina(s[0], " + ", s[2]);
+	test_ab(a, b);
+
+	a = "weweweweewaaaaaa|string";
+	b = strjoina(s[5], s[4], "|", s[3]);
+	test_ab(a, b);
+
+	a = "abcd + blah blah";
+	b = strjoin(s[0], " + ", s[2], NULL);
+	test_ab(a, b);
+
+	a = "weweweweewaaaaaa|string";
+	b = strjoin(s[5], s[4], "|", s[3], NULL);
+	test_ab(a, b);
+
+	a = "abcd:)test:)blah blah:)string:)aaaaaa:)weweweweew";
+	b = strvjoin(s, ":)");
+	test_ab(a, b);
+
+	return 0;
+}
+
+int print_strv(const char **p) {
+	unsigned i;
+	assert(p);
+
+	for(i = 0; p[i]; i++)
+		printf("\t%u. %s\n", i+1, p[i]);
+
+	return 0;
+}
+
+int test_realloc_cleanup() {
+	unsigned i;
+	size_t a = 0;
+	__free_strv const char **strings = NULL;
+
+	for (i = 0; i < 6; i++) {
+		if(!__realloc(strings, a, i+1))
+			return -ENOMEM;
+
+		strings[i] = strdup(s[i]);
+		strings[i+1] = NULL;
+	}
+
+	return 0;
+}
+
+typedef struct TestStruct {
+	unsigned v;
+	unsigned w;
+	bool freed;
+} TestStruct;
+
+int new_test_struct(TestStruct** s, unsigned a, unsigned b) {
+	TestStruct *p;
+
+	p = alloc_zero(TestStruct, 1);
+	if (!p)
+		return -ENOMEM;
+
+	p->v = a;
+	p->w = b;
+
+	*s = p;
+
+	return 0;
+}
+
+int cmp_test_struct(TestStruct *s) {
+	if (!s)
+		return -EINVAL;
+
+	if (s->v != 0xCAFEBABE)
+		return -EINVAL;
+
+	if (s->w != 0xDEADB347)
+		return -EINVAL;
+
+	if (s->freed)
+		return -EINVAL;
+
+	return 0;
+}
+
+void free_test_struct(TestStruct *s) {
+	if (!s)
+		return;
+
+	s->freed = true;
+}
+
+CLEANUP_FUNC(TestStruct *, free_test_struct);
+#define __free_test_struct __cleanup(free_test_structp)
+
+int scope_out_test(TestStruct *ts) {
+	__free_test_struct TestStruct *q = ts;
+	return q->freed ? -EINVAL : 0;
+}
+
+int scope_check_freed(TestStruct *ts) {
+	__free_test_struct TestStruct *q = ts;
+	if (true) 
+		q = NULL;
+	return ts->freed ? -EINVAL : 0;
+}
+
+int main(int argc, char **argv)
+{
+	TestStruct* ts; 
+	int r;
+
+	(void) test_strjoin();
+	(void) test_strsepjoin();
+
+	r = test_realloc_cleanup();
+	test(r, "realloc_cleanup");
+
+	r = new_test_struct(&ts, 0xCAFEBABE, 0xDEADB347);
+	test(r, "new_test_struct");
+
+	r = cmp_test_struct(ts);
+	test(r, "cmp_test_struct");
+
+	r = scope_check_freed(ts);
+	test(r, "scope_check_freed");
+
+	r = scope_out_test(ts);
+	test(r, "scope_in_test");
+
+	r = ts->freed ? 0 : -EINVAL;
+	test(r, "scope_out_test");
+
+	return r;
+}
+


### PR DESCRIPTION
Hey,

this patchset contains a bunch of code changes to make the code more robust and resilient:
- added safe `strjoin` family of functions
- added `attribute((cleanup))` destructors
- added checks for `strdup` allocation success
- removed `ptr != NULL` checks from `alloca`'d pointers as they are invalid
- replaced `*printf*` family of functions with `strjoin`/`strjoina`
- added a few tests for the common functions

What I have on my radar:
- use prepared statements for database interactions _or_ escape all parameters to queries
- add more `size_t` wrapping checks to the common functions
- handle external processes better
- fix spelling (`tennant` -> `tenant`)
