### PR TITLE
Derivative containers

### DIFF
--- a/doc/freight-builder.1
+++ b/doc/freight-builder.1
@@ -119,8 +119,8 @@ A list of details to include when the container is packaged up as an rpm
 .B post_script
 .PP
 Path to a file to be executed in the container root after the install is
-complete.  Note that the script is run in a chroot so external files will not be
-accessible
+complete.  Note the ENVIRONMENT VARIABLES section below for information about
+the script environment
 
 .B yum_opts
 .PP
@@ -138,3 +138,14 @@ executed
 .PP
 .B user
 The container will run as the specified user
+
+.SH ENVIRONMENT VARIABLES
+Environment variables are used to convey information about the container being
+built to the post_script that may be optionally specified in the manifest file.
+The following Environment variables are set and accessible to the post_script
+.TP
+.B FREIGHT_CONTAINERFS
+This variable points to the root of the container file system.  It can be used
+as a chroot destination for modifying the container, or as a destination
+directory base for copying additional files into the container
+

--- a/doc/freight-builder.1
+++ b/doc/freight-builder.1
@@ -127,8 +127,7 @@ the script environment
 .PP
 This optional setting allows for the creation of derivative containers.  That is
 to say, the resultant container will only contain the changes made via the
-post_script option (or interactively if no post_script is specified) from the
-container specified via parent_container.
+post_script option from the container specified via parent_container.
 
 .B yum_opts
 .PP

--- a/doc/freight-builder.1
+++ b/doc/freight-builder.1
@@ -36,8 +36,15 @@ Write the resultant source and binary rpms to this directory
 .B -c | --container <path/to/container/rpm>
 Instead of building an rpm, introspect an rpm to see if any packages need
 updates within the container
-.SH MANIFEST FILE FORMAT 
+.TP
+.B -v | --verbose
+Make freight-builder output lots of diagnostic information
+.TP.
+.B -w | --workdir
+Specify the base directory in which freight-builder uses as working space to
+build rpms
 
+.SH MANIFEST FILE FORMAT 
 The Manifest file codifies the contents of a container image and generally has
 this format:
 

--- a/doc/freight-builder.1
+++ b/doc/freight-builder.1
@@ -39,10 +39,13 @@ updates within the container
 .TP
 .B -v | --verbose
 Make freight-builder output lots of diagnostic information
-.TP.
-.B -w | --workdir
+.TP
+.B -w | --workdir <path/to/workdir>
 Specify the base directory in which freight-builder uses as working space to
 build rpms
+.TP
+.B -r | --relver
+The release version to specify when inspecting or deriving child containers
 
 .SH MANIFEST FILE FORMAT 
 The Manifest file codifies the contents of a container image and generally has

--- a/doc/freight-builder.1
+++ b/doc/freight-builder.1
@@ -80,6 +80,7 @@ packaging = {
 	license = "GPLv2|BSD|Proprietary";	
 	author = "Name <email>";
 	post_script ="/path/to/script";
+	parent_container = "parent-container-nvr";
 };
 
 yum_opts = {
@@ -121,6 +122,13 @@ A list of details to include when the container is packaged up as an rpm
 Path to a file to be executed in the container root after the install is
 complete.  Note the ENVIRONMENT VARIABLES section below for information about
 the script environment
+
+.B parent_container
+.PP
+This optional setting allows for the creation of derivative containers.  That is
+to say, the resultant container will only contain the changes made via the
+post_script option (or interactively if no post_script is specified) from the
+container specified via parent_container.
 
 .B yum_opts
 .PP

--- a/examples/test-manifest/child.manifest
+++ b/examples/test-manifest/child.manifest
@@ -1,0 +1,17 @@
+
+packaging = {
+	name = "child";
+	version = "1.0";
+	release = "1";
+	summary = "child example container";
+	license = "GPLv2";
+	author = "Neil Horman <root@localhost.com>";
+	parent_container = "/home/nhorman/test-1.0-1.x86_64.rpm";
+	post_script = "./examples/test-manifest/post_install_child";
+};
+
+yum_opts = {
+	releasever = "21";
+};
+
+

--- a/examples/test-manifest/child.manifest
+++ b/examples/test-manifest/child.manifest
@@ -10,8 +10,4 @@ packaging = {
 	post_script = "./examples/test-manifest/post_install_child";
 };
 
-yum_opts = {
-	releasever = "21";
-};
-
 

--- a/examples/test-manifest/post_install
+++ b/examples/test-manifest/post_install
@@ -1,7 +1,8 @@
 #!/bin/sh
 
+setfiles /etc/selinux/targeted/contexts/files/file_contexts /
+
 #We need to setup the root password
-chcon system_u:object_r:shadow_t:s0 /etc/shadow
 echo redhat | passwd -f --stdin root
 
 #Then we need to enable the web server

--- a/examples/test-manifest/post_install
+++ b/examples/test-manifest/post_install
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+cat >> $FREIGHT_CONTAINERFS/post_install << EOF
+
 setfiles /etc/selinux/targeted/contexts/files/file_contexts /
 
 #We need to setup the root password
@@ -8,3 +10,12 @@ echo redhat | passwd -f --stdin root
 #Then we need to enable the web server
 systemctl enable httpd
 
+EOF
+
+chmod 755 $FREIGHT_CONTAINERFS/post_install
+
+cd $FREIGHT_CONTAINERFS
+
+chroot . /post_install
+
+rm -f $FREIGHT_CONTAINERFS/post_install

--- a/examples/test-manifest/post_install_child
+++ b/examples/test-manifest/post_install_child
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "post_install_child script"

--- a/examples/test-manifest/test.manifest
+++ b/examples/test-manifest/test.manifest
@@ -7,6 +7,7 @@ inherit = "./examples/test-manifest/base.manifest";
 manifest = (
 	"passwd",
 	"policycoreutils",
+	"selinux-policy-targeted",
 	"httpd"
 );
 

--- a/src/freight-agent/main.c
+++ b/src/freight-agent/main.c
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
 	case OP_MODE_CLEAN:
 		LOG(INFO, "Removing container root %s\n",
 			  config.node.container_root);
-		clean_container_root(config.node.container_root);
+		clean_container_root(api, &config);
 		break;
 	case OP_MODE_INSTALL:
 		if (!rpm) {

--- a/src/freight-agent/mode.c
+++ b/src/freight-agent/mode.c
@@ -199,21 +199,21 @@ static int init_tennant_root(const struct db_api *api,
 	/*
  	 * Now hard link the new directory trees
  	 */
-	sprintf(repo, "cp --link -a %s/common/bin/ %s/", croot, troot);
+	repo = strjoina("cp --link -a ", croot, "/common/bin/ ", troot, "/");
 	rc = run_command(repo, acfg->cmdline.verbose);
-	sprintf(repo, "cp --link -a %s/common/lib/ %s/", croot, troot);
+	repo = strjoina("cp --link -a ", croot, "/common/lib/ ", troot, "/");
 	rc |= run_command(repo, acfg->cmdline.verbose);
-	sprintf(repo, "cp --link -a %s/common/lib64/ %s/", croot, troot);
+	repo = strjoina("cp --link -a ", croot, "/common/lib64/ ", troot, "/");
 	rc |= run_command(repo, acfg->cmdline.verbose);
-	sprintf(repo, "cp --link -a %s/common/usr/ %s/", croot, troot);
+	repo = strjoina("cp --link -a ", croot, "/common/usr/ ", troot, "/");
 	rc |= run_command(repo, acfg->cmdline.verbose);
 	/* Except for var, as we want a private rpdb copy */
-	sprintf(repo, "cp -r -a %s/common/var/lib/rpm/ %s/var/lib/", croot, troot);
+	repo = strjoina("cp -r -a ", croot, "/common/var/lib/rpm/", troot, "/var/lib/");
 	rc |= run_command(repo, acfg->cmdline.verbose);
 	
 	if (rc) {
 		LOG(ERROR, "Unable to link support utilities for tennant %s\n",
-		    tennant);
+		    tenant);
 		goto out_cleanup;
 	} 
 

--- a/src/freight-agent/mode.c
+++ b/src/freight-agent/mode.c
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/vfs.h>
+#include <sys/mount.h>
 #include <fcntl.h>
 #include <libconfig.h>
 #include <mode.h>
@@ -148,6 +149,7 @@ out:
 	return rc;
 }
 
+
 static int init_tennant_root(const struct db_api *api,
 			       const char *croot,
 			       const char *tenant,
@@ -155,6 +157,9 @@ static int init_tennant_root(const struct db_api *api,
 {
 	char *dirs[]= {
 		"",
+		"bin",
+		"lib",
+		"lib64",
 		"containers",
 		"var",
 		"var/lib",
@@ -189,6 +194,17 @@ static int init_tennant_root(const struct db_api *api,
 			goto out_cleanup;
 		}
 	}
+
+	/*
+ 	 * Now hard link the new directory trees
+ 	 */
+	sprintf(repo, "cp --link -a %s/common/bin/ %s/bin/", croot, troot);
+	rc = run_command(repo, acfg->cmdline.verbose);
+	if (rc) {
+		LOG(ERROR, "Unable to link support utilities for tennant %s\n",
+		    tennant);
+		goto out_cleanup;
+	} 
 
 	/*
  	 * Create the yum.conf file
@@ -258,6 +274,7 @@ int init_container_root(const struct db_api *api,
 	int rc = -EINVAL;
 	struct tbl *table;
 	char hostname[512];
+	char cbuf[1024];
 	int r;
 	/*
 	 * Sanity check the container root, it can't be the 
@@ -297,7 +314,21 @@ int init_container_root(const struct db_api *api,
 		LOG(ERROR, "Container root must be btrfs\n");
 		goto out;
 	}
- 
+
+	/*
+ 	 * Start by creating our support binanies for use with container
+ 	 * installs
+ 	 */
+	LOG(INFO, "Install support utilities.  This could take a minute..");
+	sprintf(cbuf, "yum --installroot=%s/common "
+		      "--nogpgcheck --releasever=21 -y "
+		      "install bash btrfs-progs\n", croot); 
+	rc = run_command(cbuf, acfg->cmdline.verbose);
+	if (rc) {
+		LOG(ERROR, "Failed to install support utilities\n");
+		goto out;
+	}
+
 	/*
  	 * Now get a list of tennants
  	 */

--- a/src/freight-agent/mode.c
+++ b/src/freight-agent/mode.c
@@ -198,7 +198,13 @@ static int init_tennant_root(const struct db_api *api,
 	/*
  	 * Now hard link the new directory trees
  	 */
-	sprintf(repo, "cp --link -a %s/common/bin/ %s/bin/", croot, troot);
+	sprintf(repo, "cp --link -a %s/common/bin/ %s/", croot, troot);
+	rc = run_command(repo, acfg->cmdline.verbose);
+	sprintf(repo, "cp --link -a %s/common/lib/ %s/", croot, troot);
+	rc |= run_command(repo, acfg->cmdline.verbose);
+	sprintf(repo, "cp --link -a %s/common/lib64/ %s/", croot, troot);
+	rc |= run_command(repo, acfg->cmdline.verbose);
+
 	rc = run_command(repo, acfg->cmdline.verbose);
 	if (rc) {
 		LOG(ERROR, "Unable to link support utilities for tennant %s\n",
@@ -322,7 +328,7 @@ int init_container_root(const struct db_api *api,
 	LOG(INFO, "Install support utilities.  This could take a minute..");
 	sprintf(cbuf, "yum --installroot=%s/common "
 		      "--nogpgcheck --releasever=21 -y "
-		      "install bash btrfs-progs\n", croot); 
+		      "install sh btrfs-progs\n", croot); 
 	rc = run_command(cbuf, acfg->cmdline.verbose);
 	if (rc) {
 		LOG(ERROR, "Failed to install support utilities\n");

--- a/src/freight-agent/mode.c
+++ b/src/freight-agent/mode.c
@@ -89,9 +89,51 @@ static char *build_path(const char *base, const char *path, char *name)
 	return strjoin(base, path, name, NULL);
 }
 
-void clean_container_root(const char *croot)
+static void clean_tennant_root(const char *croot, 
+			       const char *tennant,
+			       const struct agent_config *acfg)
 {
-	recursive_dir_cleanup(croot);
+	char cmd[1024];
+
+	sprintf(cmd, "btrfs subvolume delete %s/%s", croot, tennant);
+
+	run_command(cmd, acfg->cmdline.verbose);
+}
+
+void clean_container_root(const struct db_api *api, const struct agent_config *acfg)
+{
+	char hostname[512];
+	char *cmd;
+	struct tbl *table;
+	int r;
+
+	if (gethostname(hostname, 512)) {
+		LOG(WARNING, "Could not get hostname: %s\n",
+		    strerror(errno));
+                goto clean_common;
+        }
+
+	table = get_tennants_for_host(api, hostname, acfg);
+	if (!table) {
+                LOG(WARNING, "Unable to obtain list of tennants\n");
+                goto clean_common;
+        }
+
+	for(r=0; r < table->rows; r++)
+                clean_tennant_root(acfg->node.container_root,
+				   table->value[r][1], acfg);
+
+	free_tbl(table);
+
+clean_common:
+	cmd = strjoina("btrfs subvolume delete ", acfg->node.container_root,
+		       "/common");
+	run_command(cmd, acfg->cmdline.verbose);
+
+	cmd = strjoina("btrfs subvolume delete ", acfg->node.container_root);	
+
+	run_command(cmd, acfg->cmdline.verbose);
+	return;
 }
 
 void list_containers(char *scope, const char *tenant,
@@ -149,27 +191,13 @@ out:
 	return rc;
 }
 
-
 static int init_tennant_root(const struct db_api *api,
 			       const char *croot,
 			       const char *tenant,
 			       const struct agent_config *acfg)
 {
 	char *dirs[]= {
-		"",
-		"bin",
-		"lib",
-		"lib64",
-		"usr",
 		"containers",
-		"var",
-		"var/lib",
-		"var/lib/rpm",
-		"var/lib/yum",
-		"var/cache",
-		"var/cache/yum",
-		"etc",
-		"etc/yum.repos.d",
 		NULL,
 	};
 	char *troot;
@@ -187,35 +215,26 @@ static int init_tennant_root(const struct db_api *api,
  	 */
 	rc = -EINVAL;
 	LOG(INFO, "Building freight-agent environment\n");
-	for (i=0; dirs[i]; i++) {
+
+	/*
+	 * Start by creating a subvolume for the tennant
+	 */
+	repo = strjoina("btrfs subvolume snapshot ", croot,
+			"/common ", troot);
+	if (run_command(repo, acfg->cmdline.verbose)) {
+		LOG(ERROR, "Unable to create a tennant subvolume\n");
+		goto out;
+	}
+
+	LOG(INFO, "Building freight-agent environment\n");
+	for (i=0; dirs[i] != NULL; i++) {
 		rc = build_dir(troot, dirs[i]);
 		if (rc) {
 			LOG(ERROR, "Could not create %s: %s\n",
-				dirs[i], strerror(rc));
-			goto out_cleanup;
+			   dirs[i], strerror(rc));
+			goto out;
 		}
 	}
-
-	/*
- 	 * Now hard link the new directory trees
- 	 */
-	repo = strjoina("cp --link -a ", croot, "/common/bin/ ", troot, "/");
-	rc = run_command(repo, acfg->cmdline.verbose);
-	repo = strjoina("cp --link -a ", croot, "/common/lib/ ", troot, "/");
-	rc |= run_command(repo, acfg->cmdline.verbose);
-	repo = strjoina("cp --link -a ", croot, "/common/lib64/ ", troot, "/");
-	rc |= run_command(repo, acfg->cmdline.verbose);
-	repo = strjoina("cp --link -a ", croot, "/common/usr/ ", troot, "/");
-	rc |= run_command(repo, acfg->cmdline.verbose);
-	/* Except for var, as we want a private rpdb copy */
-	repo = strjoina("cp -r -a ", croot, "/common/var/lib/rpm/", troot, "/var/lib/");
-	rc |= run_command(repo, acfg->cmdline.verbose);
-	
-	if (rc) {
-		LOG(ERROR, "Unable to link support utilities for tennant %s\n",
-		    tenant);
-		goto out_cleanup;
-	} 
 
 	/*
  	 * Create the yum.conf file
@@ -231,7 +250,7 @@ static int init_tennant_root(const struct db_api *api,
 		rc = errno;
 		LOG(ERROR, "Unable to write /etc/yum.conf: %s\n",
 			strerror(errno));
-		goto out_cleanup;
+		goto out;
 	}
 
 	fprintf(fptr, "[main]\n");
@@ -239,6 +258,12 @@ static int init_tennant_root(const struct db_api *api,
 	fprintf(fptr, "logfile=/var/log/yum.log\n");
 	fprintf(fptr, "gpgcheck=0\n"); /* ONLY FOR NOW! */
 	fclose(fptr);
+
+	sprintf(repo, "rm -f %s/etc/yum.repos.d/*", troot);
+	if (run_command(repo, acfg->cmdline.verbose)) {
+		LOG(ERROR, "Unable to remove cloned yum repos\n");
+		goto out;
+	}
 
 	/*
  	 * Now we need to check the database for our repository configuration
@@ -255,7 +280,7 @@ static int init_tennant_root(const struct db_api *api,
 			if (!fptr) {
 				LOG(ERROR, "Unable to write /etc/yum.repos.d/%s.repo\n",
 					yum_config->value[i][0]);
-				goto out_cleanup;
+				goto out;
 			}
 
 			fprintf(fptr, "[%s]\n", yum_config->value[i][0]);
@@ -268,11 +293,6 @@ static int init_tennant_root(const struct db_api *api,
 
 		free_tbl(yum_config);
 	}
-
-	goto out;
-
-out_cleanup:
-	clean_container_root(troot);
 out:
 	return rc;
 }
@@ -280,7 +300,6 @@ out:
 int init_container_root(const struct db_api *api,
 			const struct agent_config *acfg)
 {
-	struct statfs buf;
 	const char *croot = acfg->node.container_root;
 	int rc = -EINVAL;
 	struct tbl *table;
@@ -301,35 +320,28 @@ int init_container_root(const struct db_api *api,
 	 * Start by emptying the container root
 	 */
         LOG(INFO, "Cleaning container root\n");
-        clean_container_root(croot);
+        clean_container_root(api, acfg);
 
-	/*
- 	 * Create the overall root
- 	 */
-	if ((rc = build_dir(croot, ""))) {
-		LOG(ERROR, "Could not create %s %s\n",
-			croot, strerror(rc));
-		goto out;
-	}
-
-	/*
- 	 * Check to make sure its btrfs
- 	 */
-	if (statfs(acfg->node.container_root, &buf) == -1) {
-		LOG(ERROR, "Cannnot interrogate container_root %s: %s\n",
-		acfg->node.container_root, strerror(errno));
-		goto out;
-	}
-
-	if (buf.f_type != BTRFS_SUPER_MAGIC) {
-		LOG(ERROR, "Container root must be btrfs\n");
-		goto out;
-	}
+	sprintf(cbuf, "btrfs subvolume create %s", croot);
 
 	/*
  	 * Start by creating our support binanies for use with container
  	 * installs
  	 */
+	rc = run_command(cbuf, acfg->cmdline.verbose);
+	if (rc) {
+		LOG(ERROR, "Failed to create container root subvolume\n");
+		goto out;
+	}
+
+	sprintf(cbuf, "btrfs subvolume create %s/common", croot);
+
+	rc = run_command(cbuf, acfg->cmdline.verbose);
+	if (rc) {
+		LOG(ERROR, "Failed to create container root common subvolume\n");
+		goto out;
+	}
+
 	LOG(INFO, "Install support utilities.  This could take a minute..");
 	sprintf(cbuf, "yum --installroot=%s/common "
 		      "--nogpgcheck --releasever=21 -y "
@@ -362,12 +374,22 @@ int init_container_root(const struct db_api *api,
 	/*
  	 * Now init the root space for each tennant
  	 */
-	for(r = 0; r < table->rows; r++)
+	for(r = 0; r < table->rows; r++) {
 		rc = init_tennant_root(api, croot, table->value[r][1], acfg);
-
+		if (rc) {
+			LOG(ERROR, "Unable to establish all tennants, cleaning...\n");
+			goto out_clean;
+		}
+	}
+out_free:
 	free_tbl(table);
 out:
 	return rc;
+out_clean:
+	for(r=0; r < table->rows; r++)
+		clean_tennant_root(croot, table->value[r][1], acfg);
+	goto out_free;
+
 }
 
 static void daemonize(const struct agent_config *acfg)

--- a/src/freight-agent/mode.c
+++ b/src/freight-agent/mode.c
@@ -204,8 +204,10 @@ static int init_tennant_root(const struct db_api *api,
 	rc |= run_command(repo, acfg->cmdline.verbose);
 	sprintf(repo, "cp --link -a %s/common/lib64/ %s/", croot, troot);
 	rc |= run_command(repo, acfg->cmdline.verbose);
-
-	rc = run_command(repo, acfg->cmdline.verbose);
+	/* Except for var, as we want a private rpdb copy */
+	sprintf(repo, "cp -r -a %s/common/var/lib/rpm/ %s/var/lib/", croot, troot);
+	rc |= run_command(repo, acfg->cmdline.verbose);
+	
 	if (rc) {
 		LOG(ERROR, "Unable to link support utilities for tennant %s\n",
 		    tennant);
@@ -334,6 +336,10 @@ int init_container_root(const struct db_api *api,
 		LOG(ERROR, "Failed to install support utilities\n");
 		goto out;
 	}
+
+	sprintf(cbuf, "yum --installroot=%s/common "
+		      "clean all\n", croot);
+	run_command(cbuf, acfg->cmdline.verbose);
 
 	/*
  	 * Now get a list of tennants

--- a/src/freight-agent/mode.c
+++ b/src/freight-agent/mode.c
@@ -160,6 +160,7 @@ static int init_tennant_root(const struct db_api *api,
 		"bin",
 		"lib",
 		"lib64",
+		"usr",
 		"containers",
 		"var",
 		"var/lib",
@@ -203,6 +204,8 @@ static int init_tennant_root(const struct db_api *api,
 	sprintf(repo, "cp --link -a %s/common/lib/ %s/", croot, troot);
 	rc |= run_command(repo, acfg->cmdline.verbose);
 	sprintf(repo, "cp --link -a %s/common/lib64/ %s/", croot, troot);
+	rc |= run_command(repo, acfg->cmdline.verbose);
+	sprintf(repo, "cp --link -a %s/common/usr/ %s/", croot, troot);
 	rc |= run_command(repo, acfg->cmdline.verbose);
 	/* Except for var, as we want a private rpdb copy */
 	sprintf(repo, "cp -r -a %s/common/var/lib/rpm/ %s/var/lib/", croot, troot);

--- a/src/freight-agent/mode.h
+++ b/src/freight-agent/mode.h
@@ -28,7 +28,7 @@
 int init_container_root(const struct db_api *api,
 			const struct agent_config *acfg);
 
-void clean_container_root(const char *croot);
+void clean_container_root(const struct db_api *api, const struct agent_config *acfg);
 
 int install_container(const char *rpm, const char *tennant,
 		      struct agent_config *acfg);

--- a/src/freight-agent/nodb.c
+++ b/src/freight-agent/nodb.c
@@ -60,9 +60,9 @@ struct tbl* nodb_get_table(const char *tbl, const char *cols, const char *filter
  	 * From the tennant_hosts table
  	 */
 	if (!strcmp(tbl, "tennant_hosts")) {
-		table = alloc_tbl(1,1);
+		table = alloc_tbl(1,2);
 		if (table)
-			table->value[0][0] = strdup("local");
+			table->value[0][1] = strdup("local");
 	}
 
 	return table;

--- a/src/freight-builder/main.c
+++ b/src/freight-builder/main.c
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
 	build_env = init_pkg_mgmt(PKG_YUM, &manifest);
 	if (build_env == NULL) {
 		LOG(ERROR, "Failed to init build temp directory\n");
-		goto out_release;
+		goto out_cleanup;
 	}
 
 	if (container_rpm) {

--- a/src/freight-builder/main.c
+++ b/src/freight-builder/main.c
@@ -37,6 +37,7 @@ struct option lopts[] = {
 	{"source", 0, NULL, 's'},
 	{"check", 1, NULL, 'c'},
 	{"verbose", 0, NULL, 'v'},
+	{"workdir", 1, NULL, 'w'},
 	{ 0, 0, 0, 0}
 };
 #endif
@@ -49,6 +50,7 @@ static void usage(char **argv)
 			"[-k | --keep] "
 			"<[-m | --manifest]  config> "
 			"<-c | --check=<container rpm>> "
+			"[-w | --workdir <dir>] "
 			"[-v] | [--verbose]\n", argv[0]);
 #else
 	LOG(INFO,  "%s [-h] [-k] [-s] [-v] "
@@ -56,7 +58,7 @@ static void usage(char **argv)
 #endif
 }
 
-#define OPTSTRING "h,m:ko:sc:v"
+#define OPTSTRING "h,m:ko:sc:vw:"
 
 int main(int argc, char **argv)
 {
@@ -70,6 +72,8 @@ int main(int argc, char **argv)
 	int source_only=0;
 	char *container_rpm = NULL;
 	int verbose = 0;
+	char *workdir = NULL;
+
 	/*
  	 * Parse command line options
  	 */
@@ -105,6 +109,10 @@ int main(int argc, char **argv)
 			break;
 		case 'v':
 			verbose = 1;
+			break;
+		case 'w':
+			workdir = optarg;
+			break;
 		}
 	}
 
@@ -128,6 +136,7 @@ int main(int argc, char **argv)
  	 */
 	manifest.opts.output_path = output;
 	manifest.opts.verbose = verbose;
+	manifest.opts.workdir = workdir;
 
 	/*
  	 * Setup the builder working env

--- a/src/freight-builder/manifest.c
+++ b/src/freight-builder/manifest.c
@@ -77,6 +77,7 @@ void release_manifest(struct manifest *manifest)
 	free(manifest->package.version);
 	free(manifest->package.name);
 	free(manifest->package.post_script);
+	free(manifest->package.parent_container);
 	free(manifest->yum.releasever);
 
 	memset(manifest, 0, sizeof(struct manifest));
@@ -241,71 +242,72 @@ static int parse_packaging(struct config_t *config, struct manifest *manifest)
 	tmp = config_setting_get_member(pkg, "version");
 	if (!tmp) {
 		LOG(ERROR, "You must specify a package version\n");
-		goto out_name;
+		goto out_free;
 	}
 	manifest->package.version = strdup(config_setting_get_string(tmp));
 	if (!manifest->package.version)
-		goto out_name;
+		goto out_free;
 
 	tmp = config_setting_get_member(pkg, "release");
 	if (!tmp) {
 		LOG(ERROR, "You must specify a package release\n");
-		goto out_version;
+		goto out_free;
 	}
 	manifest->package.release = strdup(config_setting_get_string(tmp));
 	if (!manifest->package.release)
-		goto out_version;
+		goto out_free;
 
 	tmp = config_setting_get_member(pkg, "summary");
 	if (!tmp) {
 		LOG(ERROR, "You must specify a package summary\n");
-		goto out_release;
+		goto out_free;
 	}
 	manifest->package.summary = strdup(config_setting_get_string(tmp));
 	if (!manifest->package.summary)
-		goto out_release;
+		goto out_free;
 
 	tmp = config_setting_get_member(pkg, "license");
 	if (!tmp) {
 		LOG(ERROR, "You must specify a package license\n");
-		goto out_summary;
+		goto out_free;
 	}
 	manifest->package.license = strdup(config_setting_get_string(tmp));
 	if (!manifest->package.license)
-		goto out_summary;
+		goto out_free;
 
 	tmp = config_setting_get_member(pkg, "author");
 	if (!tmp) {
 		LOG(ERROR, "You must specify a package author\n");
-		goto out_license;
+		goto out_free;
 	}
 	manifest->package.author = strdup(config_setting_get_string(tmp));
 	if (!manifest->package.author)
-		goto out_license;
+		goto out_free;
 	
 	tmp = config_setting_get_member(pkg, "post_script");
 	if (tmp) {
 		manifest->package.post_script = 
 			strdup(config_setting_get_string(tmp));
 		if (!manifest->package.post_script)
-			goto out_author;
+			goto out_free;
 	}
 
+	tmp = config_setting_get_member(pkg, "parent_container");
+	if (tmp)
+		manifest->package.parent_container = 
+			strdup(config_setting_get_string(tmp));
 	rc = 0;
 	goto out;
 
-out_author:
-	free(manifest->package.author);
-out_license:
+out_free:
 	free(manifest->package.license);
-out_summary:
 	free(manifest->package.summary);
-out_release:
 	free(manifest->package.release);
-out_version:
 	free(manifest->package.version);
-out_name:
+	free(manifest->package.author);
 	free(manifest->package.name);
+	free(manifest->package.post_script);
+	free(manifest->package.parent_container);
 out:
 	return rc;
 }

--- a/src/freight-builder/manifest.h
+++ b/src/freight-builder/manifest.h
@@ -65,6 +65,7 @@ struct container_opts {
  */
 struct cmdline_options {
 	char *output_path;
+	char *workdir;
 	int verbose;
 };
 

--- a/src/freight-builder/manifest.h
+++ b/src/freight-builder/manifest.h
@@ -50,6 +50,7 @@ struct packaging {
 	char *license;
 	char *author;
 	char *post_script;
+	char *parent_container;
 };
 
 struct yum_opts {

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -322,9 +322,15 @@ static int build_spec_file(const struct manifest *manifest)
  	 * /bin/sh
  	 */
 	fprintf(repof, "%%post\n"
-		       "echo $TROOT\n"
-		       "btrfs receive -f /containers/%%{name}/btrfs.img "
-		       "/containers/%%{name}/\n");
+		       "btrfs receive -m / "
+		       "-f containers/%%{name}/btrfs.img "
+		       "containers/%%{name}/\n");
+
+	fprintf(repof, "\n\n");
+
+	fprintf(repof, "%%preun\n"
+		       "btrfs subvolume delete "
+		       "containers/%%{name}/snapshot\n");
 
 	/*
  	 * Spec %files section

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -122,7 +122,13 @@ static int yum_init(const struct manifest *manifest)
 	struct statfs buf;
 
 	getcwd(path, 256);
-	worktemplate = strjoin(path, "/freight-builder.XXXXXX", NULL);
+
+	if (manifest->opts.workdir)
+		worktemplate = strjoin(manifest->opts.workdir,
+				       "/freight-builder.XXXXXX", NULL);
+	else
+		worktemplate = strjoin(path,
+				       "/freight-builder.XXXXXX", NULL);
 
 	if (!worktemplate)
 		return -ENOMEM;

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -278,14 +278,17 @@ static int build_spec_file(const struct manifest *manifest)
 	/*
  	 * Now that the install is done, lets take a snapshot of the image
  	 */
+	fprintf(repof, "mkdir containers/%s/snapshot\n",
+		       manifest->package.name);
 	fprintf(repof, "btrfs subvolume snapshot -r containers/%s/containerfs "
-		       "containers/%s/snapshot\n", manifest->package.name,
+		       "containers/%s/snapshot/containerfs\n", manifest->package.name,
 		       manifest->package.name);
 
 	/*
  	 * once we have the snapshot, we export it to a file
  	 */
-	fprintf(repof, "btrfs send -f containers/%s/btrfs.img containers/%s/snapshot\n",
+	fprintf(repof, "btrfs send -f containers/%s/btrfs.img "
+		       "containers/%s/snapshot/containerfs\n",
 		       manifest->package.name, manifest->package.name);
 
 	/*
@@ -293,7 +296,9 @@ static int build_spec_file(const struct manifest *manifest)
  	 */
 	fprintf(repof, "btrfs subvolume delete containers/%s/containerfs\n",
 		       manifest->package.name);
-	fprintf(repof, "btrfs subvolume delete containers/%s/snapshot\n",
+	fprintf(repof, "btrfs subvolume delete containers/%s/snapshot/containerfs\n",
+		       manifest->package.name);
+	fprintf(repof, "rm -rf containers/%s/snapshot\n",
 		       manifest->package.name);
 
 	/*
@@ -341,7 +346,7 @@ static int build_spec_file(const struct manifest *manifest)
 
 	fprintf(repof, "%%preun\n"
 		       "btrfs subvolume delete "
-		       "containers/%%{name}/snapshot\n");
+		       "containers/%%{name}/containerfs\n");
 
 	/*
  	 * Spec %files section

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -322,7 +322,7 @@ static int build_spec_file(const struct manifest *manifest)
  	 * /bin/sh
  	 */
 	fprintf(repof, "%%post\n"
-		       "btrfs-receive -f /containers/"
+		       "btrfs receive -f /containers/"
 		       "%%{name}/btrfs.img /containers/"
 		       "%%{name}/\n");
 

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -259,9 +259,10 @@ static int build_spec_file(const struct manifest *manifest)
 		fprintf(repof, "chmod 755 ${RPM_BUILD_ROOT}"
 			       "/containers/%s/containerfs/post_script\n",
 			       manifest->package.name);
-		fprintf(repof, "chroot ${RPM_BUILD_ROOT}"
-			       "/containers/%s/containerfs "
-			       "/post_script\n", manifest->package.name);
+		fprintf(repof, "cd containers/%s/containerfs\n"
+			       "chroot . /post_script\n"
+			       "cd ../../..\n",
+			        manifest->package.name);
 		fprintf(repof, "rm -f ${RPM_BUILD_ROOT}/containers/%s/"
 			       "containerfs/post_script\n",
 			       manifest->package.name);
@@ -333,7 +334,7 @@ static int build_spec_file(const struct manifest *manifest)
 		       "if [ -n \"$AGENT_MAKE_SVOL_RW\" ]\n"
 		       "then\n"
 		       "btrfs property set -ts "
-		       "containers/%%{name}/snapshot ro false\n"i
+		       "containers/%%{name}/snapshot ro false\n"
 		       "fi\n");
 
 	fprintf(repof, "\n\n");

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -284,6 +284,8 @@ static int spec_install_primary_container(FILE * repof, const struct manifest *m
 	if (manifest->package.post_script)
 		run_post_script_in_spec(repof, manifest);
 
+	fprintf(repof, "cp %%{SOURCE2} ${RPM_BUILD_ROOT}/containers/%s/\n",
+		manifest->package.name);
 	/*
  	 * This needs to hapen last so we can clean out the yum cache
  	 */
@@ -465,6 +467,8 @@ static int build_spec_file(const struct manifest *manifest)
 	fprintf(repof, "Source0: %s-freight.tbz2\n", manifest->package.name);
 	if (manifest->package.post_script)
 		fprintf(repof, "Source1: post_script\n");
+	fprintf(repof, "Source2: container_config\n");
+
 	fprintf(repof, "\n\n");
 
 	if (manifest->package.parent_container) {
@@ -607,8 +611,8 @@ static int stage_workdir(const struct manifest *manifest)
 		}
 	}
 
-	sprintf(pbuf, "%s/containers/%s/container_config",
-		workdir, manifest->package.name);
+	sprintf(pbuf, "%s/container_config",
+		workdir);
 
 	if (config_write_file(&config, pbuf) == CONFIG_FALSE) {
 		LOG(ERROR, "Failed to write %s: %s\n",

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -80,7 +80,7 @@ static char *build_rpm_list(const struct manifest *manifest)
 		rpm = rpm->next;
 	}
 
-	return strvjoin(strings, " ");
+	return (strings) ? strvjoin(strings, " ") : NULL;
 }
 
 static struct rpm_nvr *get_nvr_from_rpm(const char *rpm)
@@ -386,7 +386,8 @@ static int spec_install_derivative_container(FILE * repof, const struct manifest
  	 * If we added any new repos, they are in the SOURCE0 tarball.  Add them
  	 * now
  	 */
-	fprintf(repof, "tar -C containers/ -x -v -f  %%{SOURCE0}\n");
+	fprintf(repof, "tar -C containers/%s/containerfs/ -x -v -f  %%{SOURCE0}\n",
+		manifest->package.name);
 
 	/*
  	 * If rpmlist is not empty, install those rpms now

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -258,7 +258,7 @@ static int spec_install_primary_container(FILE * repof, const struct manifest *m
  	 */
 	fprintf(repof, "btrfs subvolume create containers/%%{name}/containerfs\n");
 
-	fprintf(repof, "tar -C ./containers/ -x -v -f %%{SOURCE0}\n");
+	fprintf(repof, "tar -C ./containers/%s/containerfs/ -x -v -f %%{SOURCE0}\n", manifest->package.name);
 	fprintf(repof, "yum -y --installroot=${RPM_BUILD_ROOT}/containers/%s/containerfs/ "
 		       " --nogpgcheck --releasever=%s install %s\n",
 		manifest->package.name, manifest->yum.releasever, rpmlist); 

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -97,13 +97,18 @@ static int yum_build_rpm(const struct manifest *manifest)
  	 */
 	setenv("QA_RPATHS", "0x0001", 1);
 
+	/*
+ 	 * This will convert the previously built srpm into a binary rpm that
+ 	 * can serve as a containerized directory for systemd-nspawn
+ 	 */
 	cmd = strjoina("rpmbuild ", quiet, " -D\"_build_name_fmt ",
 			manifest->package.name, "-", manifest->package.version, "-",
 			manifest->package.release, ".%%{ARCH}.rpm\" -D\"__arch_install_post "
 			"/usr/lib/rpm/check-rpaths /usr/lib/rpm/check-buildroot\" -D\"_rpmdir ",
-			output_path, "\" -D \"_topdir ", workdir, "\" --rebuild ", output_path, "/",
-			manifest->package.name, "-", manifest->package.version, "-",
+			output_path, "\" -D \"_topdir ", workdir, "\" --rebuild --noclean --nocheck ",
+			output_path, "/", manifest->package.name, "-", manifest->package.version, "-",
 			manifest->package.release, ".src.rpm\n", NULL);
+
 	LOG(INFO, "Building container binary rpm\n");
 	rc = run_command(cmd, manifest->opts.verbose);
 	if (!rc)

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -329,7 +329,12 @@ static int build_spec_file(const struct manifest *manifest)
 	fprintf(repof, "%%post\n"
 		       "btrfs receive -m / "
 		       "-f containers/%%{name}/btrfs.img "
-		       "containers/%%{name}/\n");
+		       "containers/%%{name}/\n"
+		       "if [ -n \"$AGENT_MAKE_SVOL_RW\" ]\n"
+		       "then\n"
+		       "btrfs property set -ts "
+		       "containers/%%{name}/snapshot ro false\n"i
+		       "fi\n");
 
 	fprintf(repof, "\n\n");
 

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -252,19 +252,22 @@ static int build_spec_file(const struct manifest *manifest)
 	}
 
 	if (manifest->package.post_script) {
+		fprintf(repof, "export FREIGHT_CONTAINERFS=${RPM_BUILD_ROOT}/"
+			       "containers/%s/containerfs/\n",
+			       manifest->package.name);
 		fprintf(repof, "echo executing post script\n");
 		fprintf(repof, "cp %%{SOURCE1} ${RPM_BUILD_ROOT}"
-			       "/containers/%s/containerfs/\n",
+			       "/containers/%s/\n",
 			       manifest->package.name);
 		fprintf(repof, "chmod 755 ${RPM_BUILD_ROOT}"
-			       "/containers/%s/containerfs/post_script\n",
+			       "/containers/%s/post_script\n",
 			       manifest->package.name);
-		fprintf(repof, "cd containers/%s/containerfs\n"
-			       "chroot . /post_script\n"
-			       "cd ../../..\n",
+		fprintf(repof, "cd containers/%s/\n"
+			       "./post_script\n"
+			       "cd ../../\n",
 			        manifest->package.name);
 		fprintf(repof, "rm -f ${RPM_BUILD_ROOT}/containers/%s/"
-			       "containerfs/post_script\n",
+			       "post_script\n",
 			       manifest->package.name);
 	}
 

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -407,6 +407,10 @@ static int spec_install_derivative_container(FILE * repof, const struct manifest
  	 */
 	run_post_script_in_spec(repof, manifest);
 
+
+	fprintf(repof, "cp %%{SOURCE2} ${RPM_BUILD_ROOT}/containers/%s/\n",
+		manifest->package.name);
+
 	/*
  	 * Once we're done, set the new container read only
  	 */

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -101,7 +101,7 @@ static int yum_build_rpm(const struct manifest *manifest)
 			manifest->package.name, "-", manifest->package.version, "-",
 			manifest->package.release, ".%%{ARCH}.rpm\" -D\"__arch_install_post "
 			"/usr/lib/rpm/check-rpaths /usr/lib/rpm/check-buildroot\" -D\"_rpmdir ",
-			output_path, "\" --rebuild ", output_path, "/",
+			output_path, "\" -D \"_topdir ", workdir, "\" --rebuild ", output_path, "/",
 			manifest->package.name, "-", manifest->package.version, "-",
 			manifest->package.release, ".src.rpm\n", NULL);
 	LOG(INFO, "Building container binary rpm\n");

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -526,11 +526,8 @@ static int build_spec_file(const struct manifest *manifest)
 		       "btrfs receive -m / "
 		       "-f containers/%%{name}/btrfs.img "
 		       "containers/%%{name}/\n"
-		       "if [ -n \"$AGENT_MAKE_SVOL_RW\" ]\n"
-		       "then\n"
 		       "btrfs property set -ts "
-		       "containers/%%{name}/snapshot ro false\n"
-		       "fi\n");
+		       "containers/%%{name}/containerfs ro false\n");
 
 	fprintf(repof, "\n\n");
 

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -322,9 +322,9 @@ static int build_spec_file(const struct manifest *manifest)
  	 * /bin/sh
  	 */
 	fprintf(repof, "%%post\n"
-		       "btrfs receive -f /containers/"
-		       "%%{name}/btrfs.img /containers/"
-		       "%%{name}/\n");
+		       "echo $TROOT\n"
+		       "btrfs receive -f /containers/%%{name}/btrfs.img "
+		       "/containers/%%{name}/\n");
 
 	/*
  	 * Spec %files section

--- a/src/freight-builder/yum.c
+++ b/src/freight-builder/yum.c
@@ -313,8 +313,18 @@ static int build_spec_file(const struct manifest *manifest)
 	fprintf(repof, "	echo \"/containers/$i\" >> /tmp/%s.manifest\n",
 		manifest->package.name);
 	fprintf(repof, "done\n");
-	fprintf(repof, "cd -\n");
+	fprintf(repof, "cd -\n\n");
 
+	/*
+ 	 * Spec %post section
+ 	 * Note: %post scripts here need to be run with --nochroot specified
+ 	 * because wherever freight-agent installs them won't have a working
+ 	 * /bin/sh
+ 	 */
+	fprintf(repof, "%%post\n"
+		       "btrfs-receive -f /containers/"
+		       "%%{name}/btrfs.img /containers/"
+		       "%%{name}/\n");
 
 	/*
  	 * Spec %files section


### PR DESCRIPTION
Migrate freight tools to use btrfs and its subvolume snapshot feature so that we can create small derivative child containers, that maintains proper fs metadata (so selinux contexts are consistent).
